### PR TITLE
Reset mentor and mentee states to false on log out.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,8 @@ function App() {
       )
       .then((res) => {
         setAuth("", null);
+        setMentor(false);
+        setMentee(false);
       });
   };
 


### PR DESCRIPTION
Updated log out to reset mentor and mentee states to false. This will ensure a user registering will have mentor/mentee set to false, rather than holding on to the mentor/mentee status of a previously logged in user.