### PR TITLE
Enable submit session request

### DIFF
--- a/src/pages/SessionSignup/MentorCard.js
+++ b/src/pages/SessionSignup/MentorCard.js
@@ -26,11 +26,9 @@ export default function MentorCard({ mentor, selectedDay, onSlotSelect }) {
   const [selected, setSelected] = useState(null);
 
   const handleButtonChange = (event, newSelectedAvailability) => {
-    console.log(newSelectedAvailability);
     setSelected(newSelectedAvailability);
     if (newSelectedAvailability) {
-      onSlotSelect(newSelectedAvailability.pk, new Date(newSelectedAvailability.start));
-
+      onSlotSelect(newSelectedAvailability.availabilityPk, newSelectedAvailability.start, newSelectedAvailability.end)
     }
 
   };
@@ -78,11 +76,11 @@ export default function MentorCard({ mentor, selectedDay, onSlotSelect }) {
             >
               {mentor.availabilities &&
                 mentor.availabilities
-                  .filter(
-                    (availability) =>
+                  .filter(availability => (
                       new Date(availability.start).toDateString() ===
                       new Date(selectedDay).toDateString()
-                  )
+                    )
+                  ) 
                   .map((availability) => (
                     <ToggleButton
                       key={availability.pk}

--- a/src/pages/SessionSignup/SessionSignup.js
+++ b/src/pages/SessionSignup/SessionSignup.js
@@ -22,8 +22,6 @@ export default function SessionSignup({ token }) {
   const [selectedSkill, setSelectedSkill] = useState("");
   const [selectedDay, setSelectedDay] = useState("");
   const [timeBlock, setTimeBlock] = useState(30);
-  const [selectedMentorAvailability, setSelectedMentorAvailability] =
-    useState(null);
   const [selectedAvailabilityPk, setSelectedAvailabilityPk] = useState(null);
   const [selectedStartTime, setSelectedStartTime] = useState(null);
 
@@ -31,8 +29,9 @@ export default function SessionSignup({ token }) {
     setTimeBlock(event.target.value);
   };
 
-  const handleSlotSelect = (pk, start) => {
-    setSelectedAvailabilityPk(pk);
+  const handleSlotSelect = (availPk, start, end) => {
+    console.log({ availPk, start, end })
+    setSelectedAvailabilityPk(availPk);
     setSelectedStartTime(start);
   };
 
@@ -40,7 +39,7 @@ export default function SessionSignup({ token }) {
     console.log("selectedStartTime updated", selectedStartTime);
   }, [selectedStartTime]);
 
-  const getTimeBlocks = (start, end, blockLength) => {
+  const getTimeBlocks = (start, end, blockLength, slotPk) => {
     const startTime = start instanceof Date ? start : new Date(start);
     const endTime = end instanceof Date ? end : new Date(end);
     const timeBlocks = [];
@@ -53,6 +52,7 @@ export default function SessionSignup({ token }) {
       }
 
       timeBlocks.push({
+        availabilityPk: slotPk,
         start: new Date(startTime),
         end: blockEnd,
       });
@@ -144,7 +144,7 @@ export default function SessionSignup({ token }) {
                           59
                         )
                       : end;
-                  return getTimeBlocks(blockStartTime, blockEndTime, timeBlock);
+                  return getTimeBlocks(blockStartTime, blockEndTime, timeBlock, slot.pk);
                 }
 
                 return [];
@@ -169,7 +169,7 @@ export default function SessionSignup({ token }) {
   };
 
   function handleSubmitSession() {
-    if (!selectedMentorAvailability) {
+    if (!selectedAvailabilityPk) {
       alert("Please select a mentor");
       return;
     }
@@ -179,13 +179,13 @@ export default function SessionSignup({ token }) {
     }
 
     const startTime = new Date(selectedStartTime.toISOString());
-
     axios
       .post(
         `${process.env.REACT_APP_BE_URL}/sessionrequest/`,
         {
-          mentor_availability: selectedMentorAvailability,
+          mentor_availability: selectedAvailabilityPk,
           start_time: startTime,
+          session_length: timeBlock,
         },
         {
           headers: { Authorization: `Token ${token}` },


### PR DESCRIPTION
This PR makes it possible to include the id of the selected mentor's availability in the POST request to `/sessionrequest`.

- include the PK in the mentor availability array when it is first requested
- pass it back to the function in SessionRequest that is handling the slot selection
- set it in state in SessionRequest along with the selected start time
- include the availability PK and the session length in the body of the POST to `/sessionrequest` 

The request is still failing because the start time is in a format that the backend is not currently handling.

The front end formats the date like this: `"2023-05-25T00:00:00.000Z"`
But the back end expects the date in a format like `'%Y-%m-%d %H:%M:%S%z'`
This date format will be handled correctly by the backend: `"2020-05-26 16:00:00-05"`


With @GitLukeW