### PR TITLE
Added temporary solution where we alert student if they try to sign u…

### DIFF
--- a/src/pages/SessionSignup/SessionSignup.js
+++ b/src/pages/SessionSignup/SessionSignup.js
@@ -212,6 +212,10 @@ export default function SessionSignup({ token }) {
       })
       .catch((error) => {
         console.log("error:", error);
+        // Temporary solution in case mentor is already signed up during this time. Backend will be updated to prevent display of times they are already scheduled. Backend will also be updated to return a more specific error than 500 error just in case we display a scheduled time. Then we can update this logic to trigger the alert for that specific error return.
+        if (error.message === 'Request failed with status code 500') {
+          alert("A session with this mentor is already scheduled during this time.");
+        }
       });
   }
 


### PR DESCRIPTION
…p for a time when mentor is already scheduled

## **Pull Request Template**

### **1. Targeted Issue** ###

Issue 52: https://trello.com/c/5nW8TMQB/52-mentor-is-available-after-time-has-been-requested


### **2. Overview of Solution** ###

We're using a temporary solution where we alert users if they try and submit a session during a time where the mentor is already booked.

Longer term solution: Backend will be updated to prevent display of times they are already scheduled. Backend will also be updated to return a more specific error than 500 error just in case we display a scheduled time. Then we can update the logic that trigger the alert we created to user that specific error.


### **3. Tools Used** ###

I used alert and axios.catch.


### **4. Testing Strategy** ###

1) Sign up for time with mentor and verify that it has been scheduled.
2) Return to sign up page and try signing up for a new session with that mentor.
3) Verify that alert message is triggered.


### **5. Future Implications** ###

As discussed in section 2, this is a temporary solution and long term we don't want all 500 errors to trigger this alert. We have a plan to implement a more robust solution down the line.


### **6. Screenshots** ###

![Screen Shot 2023-06-19 at 11 12 47 AM](https://github.com/TeamProductionSystem/Team_Production_System/assets/108411172/6c83b03d-7f8e-4397-85db-848e37be3607)


### **7. Code Reviewers** ###

@GitLukeW 
