### PR TITLE
Sessions add loading

### DIFF
--- a/src/pages/SessionSignup/SessionSignup.js
+++ b/src/pages/SessionSignup/SessionSignup.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import MentorCard from "./MentorCard";
+import PacmanLoader from "react-spinners/PacmanLoader";
 // import SessionForm from "./SessionForm";
 
 import {
@@ -25,6 +26,7 @@ export default function SessionSignup({ token }) {
   const [selectedStartTime, setSelectedStartTime] = useState(null);
   const [selectedDayLabel, setSelectedDayLabel] = useState(""); // for highlighting the selected day
   const [issue, setIssue] = useState(false);
+  const [loading, setLoading] = useState(true); // 
   const navigate = useNavigate();
 
   const handleTimeBlockChange = (event) => {
@@ -101,6 +103,7 @@ export default function SessionSignup({ token }) {
         });
         // convert Set to array and set as state
         setSkills(Array.from(skillsSet));
+        setLoading(false);
       })
       .catch((error) => {
         console.log("error", error);
@@ -109,6 +112,7 @@ export default function SessionSignup({ token }) {
 
   useEffect(() => {
     if (selectedSkill && selectedDay) {
+      setLoading(true);
       const filteredMentors = mentors
         .map((mentor) => {
           const copyMentor = { ...mentor };
@@ -172,6 +176,7 @@ export default function SessionSignup({ token }) {
         })
         .filter(Boolean);
       setFilteredMentors(filteredMentors);
+      setLoading(false);
     }
   }, [selectedSkill, selectedDay, mentors, timeBlock]);
 
@@ -308,61 +313,72 @@ export default function SessionSignup({ token }) {
         >
           Select a Mentor for {selectedDayLabel}:
         </Typography>
-        {skills.length === 0 ? (
+        {loading === true ? (
           <Typography
-            variant="h6"
-            sx={{ marginTop: "1rem", marginLeft: "4.5rem", color: "#FFFFFF" }}
-          >
-            No mentors are currently available.
+          variant="h6"
+          sx={{ marginTop: "1rem", marginLeft: "4.5rem", color: "#FFFFFF" }}
+        >
+            Insert pacman loader
           </Typography>
         ) : (
           <>
-            {/* Conditionally render the message if no mentors are available */}
-            {selectedSkill && selectedDay && filteredMentors.length === 0 ? (
+            {skills.length === 0 ? (
               <Typography
                 variant="h6"
-                sx={{
-                  marginTop: "1rem",
-                  marginLeft: "4.5rem",
-                  color: "#FFFFFF",
-                }}
+                sx={{ marginTop: "1rem", marginLeft: "4.5rem", color: "#FFFFFF" }}
               >
-                No mentors are available for {selectedSkill} at this time.
+                No mentors are currently available.
               </Typography>
             ) : (
-              <Grid
-                container
-                marginTop={"2rem"}
-                justifyContent={"center"}
-                sx={{ paddingBottom: "5rem" }}
-              >
-                {filteredMentors.map((mentor) =>
-                  mentor.skills ? (
-                    <Grid
-                      item
-                      xs={12}
-                      sm={6}
-                      md={3}
-                      key={mentor.pk}
-                      sx={{ padding: 1 }}
-                    >
-                      <MentorCard
-                        mentor={mentor}
-                        token={token}
-                        selectedDay={selectedDay}
-                        handleSlotSelect={handleSlotSelect}
-                        handleSubmitSession={handleSubmitSession}
-                        issue={issue}
-                        setIssue={setIssue}
-                      />
-                    </Grid>
-                  ) : null
+              <>
+                {/* Conditionally render the message if no mentors are available */}
+                {selectedSkill && selectedDay && filteredMentors.length === 0 ? (
+                  <Typography
+                    variant="h6"
+                    sx={{
+                      marginTop: "1rem",
+                      marginLeft: "4.5rem",
+                      color: "#FFFFFF",
+                    }}
+                  >
+                    No mentors are available for {selectedSkill} at this time.
+                  </Typography>
+                ) : (
+                  <Grid
+                    container
+                    marginTop={"2rem"}
+                    justifyContent={"center"}
+                    sx={{ paddingBottom: "5rem" }}
+                  >
+                    {filteredMentors.map((mentor) =>
+                      mentor.skills ? (
+                        <Grid
+                          item
+                          xs={12}
+                          sm={6}
+                          md={3}
+                          key={mentor.pk}
+                          sx={{ padding: 1 }}
+                        >
+                          <MentorCard
+                            mentor={mentor}
+                            token={token}
+                            selectedDay={selectedDay}
+                            handleSlotSelect={handleSlotSelect}
+                            handleSubmitSession={handleSubmitSession}
+                            issue={issue}
+                            setIssue={setIssue}
+                          />
+                        </Grid>
+                      ) : null
+                    )}
+                  </Grid>
                 )}
-              </Grid>
+              </>
             )}
           </>
         )}
-      </Box>
+        </Box>
       {/* <SessionForm /> */}
     </Box>
   );

--- a/src/pages/SessionSignup/SessionSignup.js
+++ b/src/pages/SessionSignup/SessionSignup.js
@@ -26,7 +26,7 @@ export default function SessionSignup({ token }) {
   const [selectedStartTime, setSelectedStartTime] = useState(null);
   const [selectedDayLabel, setSelectedDayLabel] = useState(""); // for highlighting the selected day
   const [issue, setIssue] = useState(false);
-  const [loading, setLoading] = useState(true); // 
+  const [loading, setLoading] = useState(true); // loading allows data to populate, avoiding a temporary false error message
   const navigate = useNavigate();
 
   const handleTimeBlockChange = (event) => {
@@ -65,6 +65,8 @@ export default function SessionSignup({ token }) {
   };
 
   const handleDayChange = (day) => {
+    // loading only if student has selected a day and a skill
+    selectedSkill && setLoading(true);
     const today = new Date();
     today.setHours(0, 0, 0, 0); // set time to 00:00:00
     if (day === "Tomorrow") {
@@ -112,7 +114,6 @@ export default function SessionSignup({ token }) {
 
   useEffect(() => {
     if (selectedSkill && selectedDay) {
-      setLoading(true);
       const filteredMentors = mentors
         .map((mentor) => {
           const copyMentor = { ...mentor };
@@ -176,11 +177,14 @@ export default function SessionSignup({ token }) {
         })
         .filter(Boolean);
       setFilteredMentors(filteredMentors);
+      // finish loading that was initiated if student selected a day and a skill
       setLoading(false);
     }
   }, [selectedSkill, selectedDay, mentors, timeBlock]);
 
   const handleSkillChange = (event) => {
+    // loading only if student has selected a day and a skill
+    selectedDay && setLoading(true);
     setSelectedSkill(event.target.value);
   };
 

--- a/src/pages/SessionSignup/SessionSignup.js
+++ b/src/pages/SessionSignup/SessionSignup.js
@@ -13,6 +13,7 @@ import {
   Select,
   Grid,
   Typography,
+  Container,
 } from "@mui/material";
 
 export default function SessionSignup({ token }) {
@@ -318,12 +319,13 @@ export default function SessionSignup({ token }) {
           Select a Mentor for {selectedDayLabel}:
         </Typography>
         {loading === true ? (
-          <Typography
-          variant="h6"
-          sx={{ marginTop: "1rem", marginLeft: "4.5rem", color: "#FFFFFF" }}
-        >
-            Insert pacman loader
-          </Typography>
+          <Box 
+            justifyContent={"center"}
+            marginTop={"2rem"}
+            sx={{ display: "flex", paddingBottom: "5rem" }}
+            >
+            <PacmanLoader size={20} color="yellow" />
+          </Box>
         ) : (
           <>
             {skills.length === 0 ? (


### PR DESCRIPTION
## **Pull Request Template**

### **1. Targeted Issue** ###

Added the pacman loader to the sessions signup page to prevent warning messages from flashing while data is collected. This was occurring on loading a page or anytime a user had selected both a topic and a day.

Ticket #126


### **2. Overview of Solution** ###

I added a loading state and some logic to check if we are loading before displaying any other content in the "Select a mentor for:" section. I tried to match the loader position with the mentor display.


### **3. Tools Used** ###

Used Box, PacmanLoader, and a ternary statement.


### **4. Testing Strategy** ###

I tested to see that the loader displays as intended on loading the page or on selecting both a day and a time. I checked to see that the loader wasn't preventing mentors or error messages from displaying.


### **5. Future Implications** ###

-I expect we will have to rewrite some of the loading logic when the availability logic gets moved to the back end.
-We may want to reposition the error messages to match up with the loader and mentor display (centered with same padding).


### **6. Screenshots** ###

n/a


### **7. Code Reviewers** ###

n/a

