### PR TITLE
Removed handleLogout from Link, so it only gets called once when user…

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -128,7 +128,7 @@ const NavBar = ({ handleLogout, isLoggedIn, token, loading }) => {
                 </Button>
               </Box>
             ) : (
-              <Link to="/" onClick={handleLogout}>
+              <Link to="/" >
                 {loading ? (
                   <Button
                     id="loading--button"


### PR DESCRIPTION
… click logout button

## **Pull Request Template**

### **1. Targeted Issue** ###

App was trying to log the user out twice and getting an invalid token error the second time.

Ticket #100


### **2. Overview of Solution** ###

I removed the call to handleLogout from the Link in Navbar.js. It was being called both there and on the Button inside the Link. I decided to keep the Button one because I don't want it to be called when the pacman loader is displaying.


### **3. Tools Used** ###

n/a


### **4. Testing Strategy** ###

I checked the console and network tab when logging in and out.


### **5. Future Implications** ###

n/a


### **6. Screenshots** ###

n/a


### **7. Code Reviewers** ###

n/a

