### PR TITLE
docs(github): updates PR template to close issue linked to PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,9 @@
 
 ### **1. Targeted Issue** ###
 
-*(The first step to a good solution is knowing the problem. Please link the issue here.)*
+*(The first step to a good solution is knowing the problem. Please link the issue here. Make sure to say 'fixes' before the linked issue)*
 
-Issue #... or
-Ticket #...
-
+This PR fixes Issue #...
 
 ### **2. Overview of Solution** ###
 


### PR DESCRIPTION
## **Pull Request Template**

### **1. Targeted Issue** ###

This PR fixes #290 


### **2. Overview of Solution** ###

In a Github PR, when you have the word _**fixes**_ before the linked issue, when the PR is merged, the issue is automatically closed. This PR updated the github PR template to include this language so it is used by developers.


### **3. Tools Used** ###

Github PR Template

Here are all the words that can be used to close a PR in this way:

- close
- closes
- closed
- fix
- fixes
- fixed
- resolve
- resolves
- resolved

### **4. Testing Strategy** ###

None, will use this PR as the test to see if it closes the linked issue.


### **5. Future Implications** ###

Great for more automation of tasks!


### **6. Screenshots** ###



### **7. Code Reviewers** ###

@GitLukeW @nzeager 

